### PR TITLE
Typescript migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,10 @@ This project is open for contributions, currently there's some goals planned:
 - [x] Support Codeforces API
 - [x] Support S4RiS StanD JSON
 - [x] Support vJudge API to unfroze standings
+- [p] Migrate the project to Typescript (still has any values)
 - [ ] Add [CCS API](https://ccs-specs.icpc.io) compatibility (DOMjudge, Kattis, PC^2, ICPC CDS)
 - [ ] Support BOCA for LATAM competitions.
 - [ ] Refactor missing class components to functional components
-- [ ] Migrate the project to Typescript
 - [ ] Implement (F)ast Submission key command
 - [ ] Implement (A)utomatic Reveal key command
 - [ ] Support IOI-like contests (partial scoring)

--- a/README.md
+++ b/README.md
@@ -189,6 +189,6 @@ This project is open for contributions, currently there's some goals planned:
 - [ ] Add [CCS API](https://ccs-specs.icpc.io) compatibility (DOMjudge, Kattis, PC^2, ICPC CDS)
 - [ ] Support BOCA for LATAM competitions.
 - [ ] Refactor missing class components to functional components
-- [ ] Implement (F)ast Submission key command
-- [ ] Implement (A)utomatic Reveal key command
+- [ ] Implement (F)ast Submission key command (Reveal all pending solutions until AC or final WA)
+- [ ] Implement (A)utomatic Reveal key command (every X time reveal next submission)
 - [ ] Support IOI-like contests (partial scoring)

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -9,7 +9,7 @@ import { ContestData } from "../types/contestDataTypes";
 const App = () => {
   const [step, setStep] = useState("form");
   const [contestData, setContestData] = useState<ContestData>({} as ContestData);
-  const setContestDataWithLog = contestData => {
+  const setContestDataWithLog = (contestData: ContestData) => {
     console.log("neoSarisJSON", contestData);
     verifyNeoSarisJSON(contestData);
     setContestData(contestData);

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4,10 +4,11 @@ import WelcomeForm from "./Welcome";
 import Spinner from "./misc/Spinner";
 import { verifyNeoSarisJSON } from "../parsers/neosaris/neosaris-json-parser";
 import "./App.css";
+import { ContestData } from "../types/contestDataTypes";
 
 const App = () => {
   const [step, setStep] = useState("form");
-  const [contestData, setContestData] = useState({});
+  const [contestData, setContestData] = useState<ContestData>({} as ContestData);
   const setContestDataWithLog = contestData => {
     console.log("neoSarisJSON", contestData);
     verifyNeoSarisJSON(contestData);

--- a/src/components/Welcome.tsx
+++ b/src/components/Welcome.tsx
@@ -10,8 +10,8 @@ import { ContestData } from "../types/contestDataTypes";
 
 const getForm = (
   dataSource: string,
-  setContestData: React.Dispatch<React.SetStateAction<ContestData>>,
-  setStep: React.Dispatch<React.SetStateAction<string>>
+  setContestData: (contestData: ContestData) => void,
+  setStep: (step: string) => void
 ) => {
   switch (dataSource) {
     case "codeforces":
@@ -68,8 +68,8 @@ const WelcomeForm = ({
   setContestData,
   setStep,
 }: {
-  setContestData: React.Dispatch<React.SetStateAction<ContestData>>;
-  setStep: React.Dispatch<React.SetStateAction<string>>;
+  setContestData: (contestData: ContestData) => void;
+  setStep: (step: string) => void;
 }) => {
   const [dataSource, setDataSource] = useState("neosaris");
   return (

--- a/src/components/Welcome.tsx
+++ b/src/components/Welcome.tsx
@@ -6,8 +6,13 @@ import VjudgeForm from "./forms/VJudgeForm";
 import neoSarisLogo from "../assets/neoSaris/neoSaris_logo_vertical_dark.svg";
 import "./forms/Forms.css";
 import "./Welcome.css";
+import { ContestData } from "../types/contestDataTypes";
 
-const getForm = (dataSource, setContestData, setStep) => {
+const getForm = (
+  dataSource: string,
+  setContestData: React.Dispatch<React.SetStateAction<ContestData>>,
+  setStep: React.Dispatch<React.SetStateAction<string>>
+) => {
   switch (dataSource) {
     case "codeforces":
       return <CodeforcesForm setContestData={setContestData} setStep={setStep} />;
@@ -31,12 +36,16 @@ const Introduction = () => {
         ICPC-like competition. You can check the source code of this project on{" "}
         <a href="https://github.com/equetzal/neoSaris">github</a>.
       </p>
-      <hr className="introduction-separator" height="1px" width="50%" />
+      <hr className="introduction-separator" style={{ height: "1px", width: "50%" }} />
     </>
   );
 };
 
-const DataSourcePicker = ({ setDataSource }) => {
+const DataSourcePicker = ({
+  setDataSource,
+}: {
+  setDataSource: React.Dispatch<React.SetStateAction<string>>;
+}) => {
   return (
     <fieldset className="form-field">
       <label>Select a data source:</label>
@@ -55,7 +64,13 @@ const DataSourcePicker = ({ setDataSource }) => {
   );
 };
 
-const WelcomeForm = ({ setContestData, setStep }) => {
+const WelcomeForm = ({
+  setContestData,
+  setStep,
+}: {
+  setContestData: React.Dispatch<React.SetStateAction<ContestData>>;
+  setStep: React.Dispatch<React.SetStateAction<string>>;
+}) => {
   const [dataSource, setDataSource] = useState("neosaris");
   return (
     <div className="welcome-wrapper">

--- a/src/components/forms/CodeforcesForm.tsx
+++ b/src/components/forms/CodeforcesForm.tsx
@@ -6,8 +6,8 @@ const CodeforcesForm = ({
   setContestData,
   setStep,
 }: {
-  setContestData: React.Dispatch<React.SetStateAction<ContestData>>;
-  setStep: React.Dispatch<React.SetStateAction<string>>;
+  setContestData: (contestData: ContestData) => void;
+  setStep: (step: string) => void;
 }) => {
   const [contestId, setContestId] = useState("");
   const [isPrivate, setIsPrivate] = useState(false);

--- a/src/components/forms/CodeforcesForm.tsx
+++ b/src/components/forms/CodeforcesForm.tsx
@@ -1,7 +1,14 @@
 import React, { useState } from "react";
 import { getContestDataWithCodeforcesAPI } from "../../parsers/codeforces/codeforces-api-parser";
+import { ContestData } from "../../types/contestDataTypes";
 
-const CodeforcesForm = ({ setContestData, setStep }) => {
+const CodeforcesForm = ({
+  setContestData,
+  setStep,
+}: {
+  setContestData: React.Dispatch<React.SetStateAction<ContestData>>;
+  setStep: React.Dispatch<React.SetStateAction<string>>;
+}) => {
   const [contestId, setContestId] = useState("");
   const [isPrivate, setIsPrivate] = useState(false);
   const [groupId, setGroupId] = useState("");

--- a/src/components/forms/NeoSarisForm.tsx
+++ b/src/components/forms/NeoSarisForm.tsx
@@ -1,7 +1,14 @@
 import React, { useState } from "react";
 import { getContestDataWithNeoSarisJSON } from "../../parsers/neosaris/neosaris-json-parser";
+import { ContestData } from "../../types/contestDataTypes";
 
-const NeoSarisForm = ({ setContestData, setStep }) => {
+const NeoSarisForm = ({
+  setContestData,
+  setStep,
+}: {
+  setContestData: React.Dispatch<React.SetStateAction<ContestData>>;
+  setStep: React.Dispatch<React.SetStateAction<string>>;
+}) => {
   const [neoSarisJSON, setNeoSarisJSON] = useState("");
 
   const handleSubmit = async event => {

--- a/src/components/forms/NeoSarisForm.tsx
+++ b/src/components/forms/NeoSarisForm.tsx
@@ -6,8 +6,8 @@ const NeoSarisForm = ({
   setContestData,
   setStep,
 }: {
-  setContestData: React.Dispatch<React.SetStateAction<ContestData>>;
-  setStep: React.Dispatch<React.SetStateAction<string>>;
+  setContestData: (contestData: ContestData) => void;
+  setStep: (step: string) => void;
 }) => {
   const [neoSarisJSON, setNeoSarisJSON] = useState("");
 

--- a/src/components/forms/SarisStandForm.tsx
+++ b/src/components/forms/SarisStandForm.tsx
@@ -6,8 +6,8 @@ const SarisStandForm = ({
   setContestData,
   setStep,
 }: {
-  setContestData: React.Dispatch<React.SetStateAction<ContestData>>;
-  setStep: React.Dispatch<React.SetStateAction<string>>;
+  setContestData: (contestData: ContestData) => void;
+  setStep: (step: string) => void;
 }) => {
   const [sarisStandJSON, setSarisStandJSON] = useState("");
 

--- a/src/components/forms/SarisStandForm.tsx
+++ b/src/components/forms/SarisStandForm.tsx
@@ -1,7 +1,14 @@
 import React, { useState } from "react";
 import { getContestDataWithSarisStandJSON } from "../../parsers/saris-stand/saris-stand-json-parser";
+import { ContestData } from "../../types/contestDataTypes";
 
-const SarisStandForm = ({ setContestData, setStep }) => {
+const SarisStandForm = ({
+  setContestData,
+  setStep,
+}: {
+  setContestData: React.Dispatch<React.SetStateAction<ContestData>>;
+  setStep: React.Dispatch<React.SetStateAction<string>>;
+}) => {
   const [sarisStandJSON, setSarisStandJSON] = useState("");
 
   const handleSubmit = async event => {

--- a/src/components/forms/VJudgeForm.tsx
+++ b/src/components/forms/VJudgeForm.tsx
@@ -6,8 +6,8 @@ const VjudgeForm = ({
   setContestData,
   setStep,
 }: {
-  setContestData: React.Dispatch<React.SetStateAction<ContestData>>;
-  setStep: React.Dispatch<React.SetStateAction<string>>;
+  setContestData: (contestData: ContestData) => void;
+  setStep: (step: string) => void;
 }) => {
   const [contestId, setContestId] = useState("");
   const [frozenTime, setFrozenTime] = useState(0);

--- a/src/components/forms/VJudgeForm.tsx
+++ b/src/components/forms/VJudgeForm.tsx
@@ -1,7 +1,14 @@
 import React, { useState } from "react";
 import { getContestDataWithVjudgeAPI } from "../../parsers/vjudge/vjudge-api-parser";
+import { ContestData } from "../../types/contestDataTypes";
 
-const VjudgeForm = ({ setContestData, setStep }) => {
+const VjudgeForm = ({
+  setContestData,
+  setStep,
+}: {
+  setContestData: React.Dispatch<React.SetStateAction<ContestData>>;
+  setStep: React.Dispatch<React.SetStateAction<string>>;
+}) => {
   const [contestId, setContestId] = useState("");
   const [frozenTime, setFrozenTime] = useState(0);
   const [numberOfProblems, setNumberOfProblems] = useState(0);

--- a/src/components/misc/Spinner.tsx
+++ b/src/components/misc/Spinner.tsx
@@ -1,8 +1,14 @@
 import React from "react";
+import { CSSProperties } from "react";
 import { HeartSpinner } from "react-spinners-kit";
 
 //Not the best, but is what the author recommend https://github.com/davidhu2000/react-spinners/issues/53
-const style = { position: "fixed", top: "50%", left: "50%", transform: "translate(-50%, -50%)" };
+const style: CSSProperties = {
+  position: "fixed",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+};
 
 const Spinner = () => {
   return (

--- a/src/components/scoreboard/Header.tsx
+++ b/src/components/scoreboard/Header.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import "./Header.css";
 
-const Header = ({ title }) => {
+const Header = ({ title }: { title: string }) => {
   return (
     <div className="headerContainer">
       <span className="contestTitle">{title}</span>

--- a/src/components/scoreboard/ProblemBox.tsx
+++ b/src/components/scoreboard/ProblemBox.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import "./ProblemBox.css";
+import { ProblemColumn } from "../../types/scoreboardDataTypes";
 
 // problemStatus = "FirstAccepted" | "Accepted" | "Resolving" | "Pending" | "WrongAnswer" | "NoAttempted"
 
-const ProblemBox = ({ index, width, problemStatus, displayText }) => {
+const ProblemBox = ({ index, width, problemStatus, displayText }: ProblemColumn) => {
   return (
     <span className={`problemBox problemBox-${problemStatus}`} style={{ width }} key={index}>
       {displayText}

--- a/src/components/scoreboard/TableRow.tsx
+++ b/src/components/scoreboard/TableRow.tsx
@@ -10,10 +10,25 @@ import itcg from "../../assets/university_logos/itcg.png";
 import uam from "../../assets/university_logos/uam.png";
 import ug from "../../assets/university_logos/ug.png";
 import umsa from "../../assets/university_logos/umsa.png";
+import { Team } from "../../types/scoreboardDataTypes";
+import { Problem, Submission } from "../../types/contestDataTypes";
 
 const images = { cecyt13, chapingo, escom, itcg, uam, ug, umsa };
 
-class TableRow extends Component {
+interface IProps {
+  index: number;
+  team: Team;
+  numberOfProblems: number;
+  problems: Array<Problem>;
+  submissionWhenFrozen: Array<Submission>;
+  currentFrozenSubmission: Submission | null;
+  savedCurrentFrozenSubmission: Submission | null;
+  classNameForThisRow: string;
+}
+
+interface IState {}
+
+class TableRow extends Component<IProps, IState> {
   getImageForTeam(url) {
     return images[url] ?? defaultImage;
   }
@@ -21,12 +36,12 @@ class TableRow extends Component {
   numberOfTriesOnAcceptedProblem(problemLetter) {
     let team = this.props.team;
     return problemLetter;
-    for (let i = 0; i < this.props.numberOfProblems; i++) {
-      if (this.props.problems[i].index === problemLetter) {
-        return team.triesOnProblems[i] + 1 + " - " + team.penaltyOnProblem[i];
-      }
-    }
-    return problemLetter;
+    // for (let i = 0; i < this.props.numberOfProblems; i++) {
+    //   if (this.props.problems[i].index === problemLetter) {
+    //     return team.triesOnProblems[i] + 1 + " - " + team.penaltyOnProblem[i];
+    //   }
+    // }
+    // return problemLetter;
   }
 
   numberOfTriesOnTriedProblem(problemLetter) {
@@ -136,11 +151,7 @@ class TableRow extends Component {
   isAPendingProblemOnThisRow(problemLetter) {
     let team = this.props.team;
     let savedCurrentFrozenSubmission = this.props.savedCurrentFrozenSubmission;
-    if (
-      savedCurrentFrozenSubmission === undefined ||
-      savedCurrentFrozenSubmission === null ||
-      savedCurrentFrozenSubmission.length === 0
-    ) {
+    if (savedCurrentFrozenSubmission === null) {
       return false;
     }
     for (let i = 0; i < this.props.numberOfProblems; i++) {

--- a/src/components/scoreboard/TableRow.tsx
+++ b/src/components/scoreboard/TableRow.tsx
@@ -10,7 +10,7 @@ import itcg from "../../assets/university_logos/itcg.png";
 import uam from "../../assets/university_logos/uam.png";
 import ug from "../../assets/university_logos/ug.png";
 import umsa from "../../assets/university_logos/umsa.png";
-import { Team } from "../../types/scoreboardDataTypes";
+import { ProblemColumn, Team } from "../../types/scoreboardDataTypes";
 import { Problem, Submission } from "../../types/contestDataTypes";
 
 const images = { cecyt13, chapingo, escom, itcg, uam, ug, umsa };
@@ -197,7 +197,7 @@ class TableRow extends Component<IProps, IState> {
     let sizeProblem = 84.0 / this.props.numberOfProblems;
     let widthPercentage = sizeProblem + "%";
 
-    let problemColumns = problems.map(problem => {
+    let problemColumns: Array<ProblemColumn> = problems.map(problem => {
       let verdict = "NoAttempted";
       let textToShowInProblem = problem.index;
 
@@ -226,7 +226,7 @@ class TableRow extends Component<IProps, IState> {
         problemStatus: verdict,
         displayText: textToShowInProblem,
       };
-    });
+    }) as ProblemColumn[];
 
     let classNameForEachRow = "scoreboardTableGrayRow";
     if (this.thisRowShhouldBeSelected(problems) === true) {

--- a/src/parsers/codeforces/codeforces-api-parser.ts
+++ b/src/parsers/codeforces/codeforces-api-parser.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { sha512 } from "js-sha512";
+import { ContestData } from "../../types/contestDataTypes";
 
 const buildParams = ({
   method,
@@ -116,7 +117,7 @@ export const getContestData = async ({
     contestants: response.result.rows.map((row, index) => {
       return {
         id: index,
-        name: row.party.teamName || row.party.members[0].handle || `NO_TEAM_NAME_${id}`,
+        name: row.party.teamName || row.party.members[0].handle || `NO_TEAM_NAME_${index}`,
       };
     }),
   };
@@ -146,7 +147,7 @@ export const getContestDataWithCodeforcesAPI = async ({
     apiKey,
     apiSecret,
   });
-  const JSONobject = {
+  const JSONobject: ContestData = {
     contestMetadata: contestData.contestData,
     problems: contestData.problems,
     contestants: contestData.contestants,

--- a/src/parsers/neosaris/neosaris-json-parser.ts
+++ b/src/parsers/neosaris/neosaris-json-parser.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { ContestData } from "../../types/contestDataTypes";
 
 const Data = z.object({
   contestMetadata: z.object({
@@ -36,28 +37,25 @@ const Data = z.object({
   ),
 });
 
-export const verifyNeoSarisJSON = contestData => {
+export function verifyNeoSarisJSON(contestData: ContestData) {
   const result = Data.safeParse(contestData);
   if (!result.success) {
     console.log("Zod Result", result);
     alert(
       result.error.issues
         .map(issue => {
-          return `Error ${issue.code}, for ${issue.path.join(".")} expected ${issue.number}, got ${
-            issue.received
-          }`;
+          return `Error ${issue.code}, for ${issue.path.join(".")}`;
         })
         .join("\n")
     );
     throw new Error("Invalid neoSaris JSON");
   }
   return contestData;
-};
+}
 
-export const getContestDataWithNeoSarisJSON = rawText => {
-  let contestData = {};
-  contestData = JSON.parse(rawText);
+export function getContestDataWithNeoSarisJSON(rawText: string) {
+  let contestData = JSON.parse(rawText) as ContestData;
   console.log("neoSaris JSON, Input Object", contestData);
   verifyNeoSarisJSON(contestData);
   return contestData;
-};
+}

--- a/src/parsers/saris-stand/saris-stand-json-parser.ts
+++ b/src/parsers/saris-stand/saris-stand-json-parser.ts
@@ -1,3 +1,4 @@
+import { ContestData } from "../../types/contestDataTypes";
 const verifyObject = contestData => {
   if (contestData == null) {
     throw new Error("contestData is null or undefined!");
@@ -66,7 +67,7 @@ const verifyObject = contestData => {
   });
 };
 
-export const getContestDataWithSarisStandJSON = rawText => {
+export const getContestDataWithSarisStandJSON = (rawText: string) => {
   const oldSarisData = JSON.parse(rawText);
   console.log("S4RiS StanD JSON, Input Object", oldSarisData);
   verifyObject(oldSarisData);
@@ -96,5 +97,5 @@ export const getContestDataWithSarisStandJSON = rawText => {
         verdict: run.success ? "ACCEPTED" : "WRONG_ANSWER",
       };
     }),
-  };
+  } as ContestData;
 };

--- a/src/parsers/vjudge/vjudge-api-parser.ts
+++ b/src/parsers/vjudge/vjudge-api-parser.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { ContestData } from "../../types/contestDataTypes";
 
 const buildParams = () => {
   return {
@@ -18,7 +19,7 @@ export const getContestData = async (frozenTime, contestId, numberOfProblems) =>
       method: "GET",
       url: `https://vjudge.net/contest/rank/single/${contestId}`,
       headers: buildHeaders(),
-      params: buildParams(contestId),
+      params: buildParams(),
     })
     .catch(error => {
       throw new Error(`Error while making vJudge API request:\n${error.message}`);
@@ -34,8 +35,8 @@ export const getContestData = async (frozenTime, contestId, numberOfProblems) =>
   const problems = [...Array(numberOfProblems).keys()].map(idx => {
     return String.fromCharCode("A".charCodeAt(0) + idx);
   });
-  const teamName = new Map();
-  Object.entries(response.participants).forEach((value, idx) => {
+  const teamName = new Map<string, string>();
+  Object.entries(response.participants).forEach((value: any, idx) => {
     teamName.set(value[0], value[1][0]);
   });
 
@@ -47,7 +48,7 @@ export const getContestData = async (frozenTime, contestId, numberOfProblems) =>
       type: "ICPC",
     },
     problems: problems,
-    contestants: Object.entries(response.participants).map((value, idx) => {
+    contestants: Object.entries(response.participants).map((value: any, idx) => {
       return { id: idx, name: value[1][0] };
     }),
     submissions: response.submissions
@@ -65,7 +66,7 @@ export const getContestData = async (frozenTime, contestId, numberOfProblems) =>
 
 export const getContestDataWithVjudgeAPI = async (frozenTime, contestId, numberOfProblems) => {
   const contestData = await getContestData(frozenTime, contestId, numberOfProblems);
-  const JSONobject = {
+  const JSONobject: ContestData = {
     contestMetadata: contestData.contestData,
     contestants: contestData.contestants,
     problems: contestData.problems.map(letter => {
@@ -77,6 +78,6 @@ export const getContestDataWithVjudgeAPI = async (frozenTime, contestId, numberO
       wrongAnswerWithoutPenalty: [],
     },
     submissions: contestData.submissions,
-  };
+  } as ContestData;
   return JSONobject;
 };

--- a/src/types/contestDataTypes.ts
+++ b/src/types/contestDataTypes.ts
@@ -1,41 +1,41 @@
 export type ContestMetadata = {
-  duration: Number; //Duration in minutes
-  frozenTimeDuration: Number; //Duration of the frozen time in minutes
-  name: String; // Title to display for the problem
+  duration: number; //Duration in minutes
+  frozenTimeDuration: number; //Duration of the frozen time in minutes
+  name: string; // Title to display for the problem
   type: "ICPC"; // Type of contest to evaluate
   //^ We can add a future type for IOI to identify IOI contests
 };
 export type Problem = {
   //0 = first problem, etc.
-  index: String; //Letter of the problem
-  name?: String; //Actual name of the problem
+  index: string; //Letter of the problem
+  name?: string; //Actual name of the problem
   //Here we can add subtasks if we need to evaluate IOI contests
 };
 export type Contestant = {
-  id: Number; //Unique number to identify this contestant
-  name: String; //Name of the contestant
-  school?: String; //Name of represented university/school/institution
-  iconName?: String; //Id of the icon to display for this contestant
+  id: number; //Unique number to identify this contestant
+  name: string; //Name of the contestant
+  school?: string; //Name of represented university/school/institution
+  iconName?: string; //Id of the icon to display for this contestant
   //For awards, we can include fields about members of the team
 };
-export type Veredict = {
-  accepted: Array<String>; //Name of the accepted verdicts
+export type Verdict = {
+  accepted: Array<string>; //Name of the accepted verdicts
   //For IOI we can add partial verdict name
-  wrongAnswerWithPenalty: Array<String>; //Name of WA verdicts that causes penalty
-  wrongAnswerWithoutPenalty: Array<String>; //Name of of WA verdicts that does not causes penalty
+  wrongAnswerWithPenalty: Array<string>; //Name of WA verdicts that causes penalty
+  wrongAnswerWithoutPenalty: Array<string>; //Name of of WA verdicts that does not causes penalty
 };
 export type Submission = {
-  timeSubmitted: Number; //Floor time in minutes of the submission, relative to the contest start.
-  contestantName: String; //Name of the contestant
-  problemIndex: String; //Should match problems array
-  verdict: String; //Should match a registered verdict
+  timeSubmitted: number; //Floor time in minutes of the submission, relative to the contest start.
+  contestantName: string; //Name of the contestant
+  problemIndex: string; //Should match problems array
+  verdict: string; //Should match a registered verdict
   //For IOI we can add the partial scores
 };
 export type ContestData = {
   contestMetadata: ContestMetadata;
   problems: Array<Problem>; //Array with an unique index for each problem
   contestants: Array<Contestant>;
-  verdicts: Veredict;
+  verdicts: Verdict;
   //For awards, we can add an object for different awards (TopRanked, FirstToSolve, Medals)
   submissions: Array<Submission>;
 };

--- a/src/types/contestDataTypes.ts
+++ b/src/types/contestDataTypes.ts
@@ -1,36 +1,41 @@
+export type ContestMetadata = {
+  duration: Number; //Duration in minutes
+  frozenTimeDuration: Number; //Duration of the frozen time in minutes
+  name: String; // Title to display for the problem
+  type: "ICPC"; // Type of contest to evaluate
+  //^ We can add a future type for IOI to identify IOI contests
+};
+export type Problem = {
+  //0 = first problem, etc.
+  index: String; //Letter of the problem
+  name?: String; //Actual name of the problem
+  //Here we can add subtasks if we need to evaluate IOI contests
+};
+export type Contestant = {
+  id: Number; //Unique number to identify this contestant
+  name: String; //Name of the contestant
+  school?: String; //Name of represented university/school/institution
+  iconName?: String; //Id of the icon to display for this contestant
+  //For awards, we can include fields about members of the team
+};
+export type Veredict = {
+  accepted: Array<String>; //Name of the accepted verdicts
+  //For IOI we can add partial verdict name
+  wrongAnswerWithPenalty: Array<String>; //Name of WA verdicts that causes penalty
+  wrongAnswerWithoutPenalty: Array<String>; //Name of of WA verdicts that does not causes penalty
+};
+export type Submission = {
+  timeSubmitted: Number; //Floor time in minutes of the submission, relative to the contest start.
+  contestantName: String; //Name of the contestant
+  problemIndex: String; //Should match problems array
+  verdict: String; //Should match a registered verdict
+  //For IOI we can add the partial scores
+};
 export type ContestData = {
-  contestMetadata: {
-    duration: Number; //Duration in minutes
-    frozenTimeDuration: Number; //Duration of the frozen time in minutes
-    name: String; // Title to display for the problem
-    type: "ICPC"; // Type of contest to evaluate
-    //^ We can add a future type for IOI to identify IOI contests
-  };
-  problems: Array<{
-    //0 = first problem, etc.
-    index: String; //Letter of the problem
-    name?: String; //Actual name of the problem
-    //Here we can add subtasks if we need to evaluate IOI contests
-  }>; //Array with an unique index for each problem
-  contestants: Array<{
-    id: Number; //Unique number to identify this contestant
-    name: String; //Name of the contestant
-    school?: String; //Name of represented university/school/institution
-    iconName?: String; //Id of the icon to display for this contestant
-    //For awards, we can include fields about members of the team
-  }>;
-  verdicts: {
-    accepted: Array<String>; //Name of the accepted verdicts
-    //For IOI we can add partial verdict name
-    wrongAnswerWithPenalty: Array<String>; //Name of WA verdicts that causes penalty
-    wrongAnswerWithoutPenalty: Array<String>; //Name of of WA verdicts that does not causes penalty
-  };
+  contestMetadata: ContestMetadata;
+  problems: Array<Problem>; //Array with an unique index for each problem
+  contestants: Array<Contestant>;
+  verdicts: Veredict;
   //For awards, we can add an object for different awards (TopRanked, FirstToSolve, Medals)
-  submissions: Array<{
-    timeSubmitted: Number; //Floor time in minutes of the submission, relative to the contest start.
-    contestantName: String; //Name of the contestant
-    problemIndex: String; //Should match problems array
-    verdict: String; //Should match a registered verdict
-    //For IOI we can add the partial scores
-  }>;
+  submissions: Array<Submission>;
 };

--- a/src/types/images.d.ts
+++ b/src/types/images.d.ts
@@ -1,0 +1,1 @@
+declare module "*.png";

--- a/src/types/images.d.ts
+++ b/src/types/images.d.ts
@@ -1,1 +1,11 @@
 declare module "*.png";
+declare module "*.svg" {
+  import * as React from "react";
+
+  export const ReactComponent: React.FunctionComponent<
+    React.SVGProps<SVGSVGElement> & { title?: string }
+  >;
+
+  const src: string;
+  export default src;
+}

--- a/src/types/scoreboardDataTypes.ts
+++ b/src/types/scoreboardDataTypes.ts
@@ -1,0 +1,11 @@
+export type Team = {
+  position: number;
+  penalty: number;
+  solved: number;
+  isProblemSolved: Array<number>;
+  isFirstToSolve: Array<number>;
+  triesOnProblems: Array<number>;
+  penaltyOnProblem: Array<number>;
+  name: string;
+  id: number;
+};

--- a/src/types/scoreboardDataTypes.ts
+++ b/src/types/scoreboardDataTypes.ts
@@ -9,3 +9,17 @@ export type Team = {
   name: string;
   id: number;
 };
+
+export type ProblemColumn = {
+  key: string;
+  index: string;
+  width: string;
+  problemStatus:
+    | "FirstAccepted"
+    | "Accepted"
+    | "Resolving"
+    | "Pending"
+    | "WrongAnswer"
+    | "NoAttempted";
+  displayText: string;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "typeRoots" : ["node_modules/@types", "src/types"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
Before refactoring the scoreboard I felt that it would be easier if it was already typed in order to keep track of what is required by the scoreboard component.

Thus I migrated everything to typescript with the least possible changes. I didn't wanted to add the rule no-any since I felt it would require more work mostly on the api side and atm the scoreboard has everything typed, so, the basic needs are fulfiled, but I'm open to enforce no-any in a latter commit if suggested.